### PR TITLE
Changes for Olden/mst

### DIFF
--- a/src/Olden/mst/manual/args.c
+++ b/src/Olden/mst/manual/args.c
@@ -1,13 +1,13 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
-#include <stdchecked.h>
+
 #pragma CHECKED_SCOPE ON
 
-extern int atoi(const char * : itype(nt_array_ptr<const char>));
+#include <stdlib.h>
 
 int NumNodes = 1;
 
-int dealwithargs(int argc, array_ptr<nt_array_ptr<char>> argv : count(argc)) {
+int dealwithargs(int argc, _Array_ptr<_Nt_array_ptr<char>> argv : count(argc)) {
   int level;
 
   if (argc > 1)

--- a/src/Olden/mst/manual/hash.c
+++ b/src/Olden/mst/manual/hash.c
@@ -1,19 +1,19 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
-#include <stdchecked.h>
+
 #include <stdlib.h>
 #include "hash.h"
 #pragma CHECKED_SCOPE ON
 
-#define printf(...) unchecked { (printf)(__VA_ARGS__); }
+#define printf(...) _Unchecked { (printf)(__VA_ARGS__); }
 #define assert(num,a) if (!(a)) {printf("Assertion failure:%d in hash\n",num); exit(-1);}
 
 static int remaining = 0;
-static array_ptr<char> temp : count(remaining);
+static _Array_ptr<char> temp : count(remaining);
 
-static array_ptr<void> localmalloc(int size) : byte_count(size)
+static _Array_ptr<void> localmalloc(int size) : byte_count(size)
 {
-  array_ptr<void> blah;
+  _Array_ptr<void> blah;
   
   if (size>remaining) 
     {
@@ -29,13 +29,13 @@ static array_ptr<void> localmalloc(int size) : byte_count(size)
 
 #define localfree(sz)
 
-Hash MakeHash(int size, ptr<int(unsigned int)> map)
+Hash MakeHash(int size, _Ptr<int(unsigned int)> map)
 {
   Hash retval = NULL;
   int i;
 
   retval = (Hash) localmalloc(sizeof(*retval));
-  retval->array = (array_ptr<HashEntry>)localmalloc(size*sizeof(HashEntry));
+  retval->array = (_Array_ptr<HashEntry>)localmalloc(size*sizeof(HashEntry));
   retval->size = size;
   for (i=0; i<size; i++)
     retval->array[i] = NULL;
@@ -43,7 +43,7 @@ Hash MakeHash(int size, ptr<int(unsigned int)> map)
   return retval;
 }
 
-unchecked void *HashLookup(unsigned int key, Hash hash)
+_Unchecked void *HashLookup(unsigned int key, Hash hash)
 {
   int j;
   HashEntry ent = NULL;
@@ -59,7 +59,7 @@ unchecked void *HashLookup(unsigned int key, Hash hash)
   return NULL;
 }
 
-unchecked void HashInsert(void *entry,unsigned int key,Hash hash)
+_Unchecked void HashInsert(void *entry,unsigned int key,Hash hash)
 {
   HashEntry ent = NULL;
   int j;
@@ -79,7 +79,7 @@ void HashDelete(unsigned key, Hash hash) {
   int j = (hash->mapfunc)(key);
   int size = hash->size;
   _Dynamic_check(j <= size);
-  ptr<HashEntry> ent = 0; 
+  _Ptr<HashEntry> ent = 0; 
   _Unchecked { ent = &hash->array[j]; }
 
   while (*ent && (*ent)->key != key) {

--- a/src/Olden/mst/manual/hash.h
+++ b/src/Olden/mst/manual/hash.h
@@ -1,29 +1,29 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
-#include <stdchecked.h>
+
 #include <stdio.h>
 
 struct hash_entry {
   unsigned int key;
   void *entry;
-  ptr<struct hash_entry> next;
+  _Ptr<struct hash_entry> next;
 };
 
 #pragma CHECKED_SCOPE ON
 
-typedef ptr<struct hash_entry> HashEntry;
+typedef _Ptr<struct hash_entry> HashEntry;
 
 struct hash {
-  array_ptr<HashEntry> array : count(size);
-  ptr<int(unsigned int)> mapfunc;
+  _Array_ptr<HashEntry> array : count(size);
+  _Ptr<int(unsigned int)> mapfunc;
   int size;
 };
 
-typedef ptr<struct hash> Hash;
+typedef _Ptr<struct hash> Hash;
 
-Hash MakeHash(int size, ptr<int(unsigned int)> map);
-unchecked void *HashLookup(unsigned int key, Hash hash);
-unchecked void HashInsert(void *entry, unsigned int key, Hash hash);
+Hash MakeHash(int size, _Ptr<int(unsigned int)> map);
+_Unchecked void *HashLookup(unsigned int key, Hash hash);
+_Unchecked void HashInsert(void *entry, unsigned int key, Hash hash);
 void HashDelete(unsigned int key, Hash hash);
 
 #pragma CHECKED_SCOPE OFF

--- a/src/Olden/mst/manual/main.c
+++ b/src/Olden/mst/manual/main.c
@@ -17,7 +17,8 @@ typedef struct fc_br {
 static BlueReturn BlueRule(Vertex inserted, Vertex vlist) 
 {
   BlueReturn retval = {0};
-  Vertex tmp = NULL, prev = NULL;
+  Vertex tmp = NULL;
+  Vertex prev = NULL;
   Hash hash = NULL;
   int dist,dist2;
   int count;
@@ -31,7 +32,7 @@ static BlueReturn BlueRule(Vertex inserted, Vertex vlist)
   retval.vert = vlist;
   retval.dist = vlist->mindist;
   hash = vlist->edgehash;
-  unchecked { dist = (int) HashLookup((unsigned int) inserted, hash); }
+  _Unchecked { dist = (int) HashLookup((unsigned int) inserted, hash); }
   /*printf("Found %d at 0x%x for 0x%x\n",dist,inserted,vlist);*/
   if (dist) 
     {
@@ -57,7 +58,7 @@ static BlueReturn BlueRule(Vertex inserted, Vertex vlist)
         {
           hash = tmp->edgehash; /* <------  6% miss in tmp->edgehash */ 
           dist2 = tmp->mindist;
-          unchecked { dist = (int) HashLookup((unsigned int) inserted, hash); }
+          _Unchecked { dist = (int) HashLookup((unsigned int) inserted, hash); }
           /*printf("Found %d at 0x%x for 0x%x\n",dist,inserted,tmp);*/
           if (dist) 
             {
@@ -106,7 +107,8 @@ static BlueReturn Do_all_BlueRule(Vertex inserted, int nproc, int pn) {
 
 static int ComputeMst(Graph graph,int numproc,int numvert) 
 {
-  Vertex inserted = NULL, tmp = NULL;
+  Vertex inserted = NULL;
+  Vertex tmp = NULL;
   int cost=0,dist;
 
   /* make copy of graph */
@@ -133,7 +135,7 @@ static int ComputeMst(Graph graph,int numproc,int numvert)
   return cost;
 }
 
-int main(int argc, array_ptr<nt_array_ptr<char>> argv : count(argc))
+int main(int argc, _Array_ptr<_Nt_array_ptr<char>> argv : count(argc))
 {
   Graph graph = NULL;
   int dist;

--- a/src/Olden/mst/manual/makegraph.c
+++ b/src/Olden/mst/manual/makegraph.c
@@ -4,7 +4,7 @@
 #pragma CHECKED_SCOPE ON
 
 /*#define assert(num,a) \
-   if (!(a)) unchecked {printf("Assertion failure:%d in makegraph\n",num); exit(-1);}*/
+   if (!(a)) _Unchecked {printf("Assertion failure:%d in makegraph\n",num); exit(-1);}*/
 
 #define CONST_m1 10000
 #define CONST_b 31415821
@@ -39,11 +39,10 @@ static int hashfunc(unsigned int key)
   return ((key>>3) % HashRange);
 }
 
-static void AddEdges(int count1, Graph retval, int numproc, 
-                     int perproc, int numvert, int j) 
+static void AddEdges(int count1, Graph retval, int numproc, int perproc, int numvert, int j) 
 {
   Vertex tmp = NULL;
-  VertexArray helper checked[MAXPROC] = {0};
+  VertexArray helper _Checked[MAXPROC] = {0};
   int i;
 
   for (i=0; i<numproc; i++) {
@@ -66,7 +65,7 @@ static void AddEdges(int count1, Graph retval, int numproc,
               offset = i % perproc;
               _Unchecked { dest = ((helper[pn].block)+offset); }
               hash = tmp->edgehash;
-              unchecked { HashInsert((void*)dist,(unsigned int) dest,hash); }
+              _Unchecked { HashInsert((void*)dist,(unsigned int) dest,hash); }
               /*assert(4, HashLookup((unsigned int) dest,hash) == (void*) dist);*/
             }
         } /* for i... */
@@ -79,8 +78,9 @@ Graph MakeGraph(int numvert, int numproc)
   int perproc = numvert/numproc;
   int i,j;
   int count1;
-  Vertex v = NULL, tmp = NULL;
-  array_ptr<struct vert_st> block : count(perproc) = NULL;
+  Vertex v = NULL;
+  Vertex tmp = NULL;
+  _Array_ptr<struct vert_st> block : count(perproc) = NULL;
   Graph retval = NULL;
 
   retval = calloc<struct graph_st>(1, sizeof(*retval));
@@ -119,7 +119,7 @@ Graph MakeGraph(int numvert, int numproc)
   return retval;
 }
 
-void chatting(nt_array_ptr<char> str) {
+void chatting(_Nt_array_ptr<char> str) {
   printf("%s", str);
 }
 

--- a/src/Olden/mst/manual/mst.h
+++ b/src/Olden/mst/manual/mst.h
@@ -1,40 +1,39 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
-#include <stdchecked.h>
+
 #include <stdlib.h>
 #include "hash.h"
 #pragma CHECKED_SCOPE ON
 #define MAXPROC 1
 
-#define printf(...) unchecked { (printf)(__VA_ARGS__); }
+#define printf(...) _Unchecked { (printf)(__VA_ARGS__); }
 extern int NumNodes;
 
 struct vert_st {
   int mindist;
-  ptr<struct vert_st> next;
+  _Ptr<struct vert_st> next;
   Hash edgehash;
 };
 
-typedef ptr<struct vert_st> Vertex;
+typedef _Ptr<struct vert_st> Vertex;
 
 struct vert_arr_st {
-  array_ptr<struct vert_st> block : count(len);
+  _Array_ptr<struct vert_st> block : count(len);
   int len;
-  array_ptr<struct vert_st> starting_vertex : bounds(block, block + len);
+  _Array_ptr<struct vert_st> starting_vertex : bounds(block, block + len);
 };
 
 typedef struct vert_arr_st VertexArray;
 
 struct graph_st {
-  struct vert_arr_st vlist checked[MAXPROC];
+  struct vert_arr_st vlist _Checked[MAXPROC];
 };
 
-typedef ptr<struct graph_st> Graph;
+typedef _Ptr<struct graph_st> Graph;
 
 Graph MakeGraph(int numvert, int numproc);
-int dealwithargs(int argc, array_ptr<nt_array_ptr<char>> argv : count(argc));
+int dealwithargs(int argc, _Array_ptr<_Nt_array_ptr<char>> argv : count(argc));
 
-int atoi(const char * : itype(nt_array_ptr<const char>));
-void chatting(nt_array_ptr<char> str);
+void chatting(_Nt_array_ptr<char> str);
 
 #pragma CHECKED_SCOPE OFF

--- a/src/Olden/mst/orig/main.c
+++ b/src/Olden/mst/orig/main.c
@@ -16,7 +16,8 @@ typedef struct fc_br {
 static BlueReturn BlueRule(Vertex inserted, Vertex vlist) 
 {
   BlueReturn retval;
-  Vertex tmp,prev;
+  Vertex tmp;
+  Vertex prev;
   Hash hash;
   int dist,dist2;
   int count;
@@ -107,7 +108,8 @@ static BlueReturn Do_all_BlueRule(Vertex inserted, int nproc, int pn) {
 
 static int ComputeMst(Graph graph,int numproc,int numvert) 
 {
-  Vertex inserted,tmp;
+  Vertex inserted;
+  Vertex tmp;
   int cost=0,dist;
 
   /* make copy of graph */

--- a/src/Olden/mst/orig/makegraph.c
+++ b/src/Olden/mst/orig/makegraph.c
@@ -38,8 +38,7 @@ static int hashfunc(unsigned int key)
   return ((key>>3) % HashRange);
 }
 
-static void AddEdges(int count1, Graph retval, int numproc, 
-                     int perproc, int numvert, int j) 
+static void AddEdges(int count1, Graph retval, int numproc, int perproc, int numvert, int j) 
 {
   Vertex tmp;
   Vertex helper[MAXPROC];
@@ -77,7 +76,8 @@ Graph MakeGraph(int numvert, int numproc)
   int perproc = numvert/numproc;
   int i,j;
   int count1;
-  Vertex v,tmp;
+  Vertex v;
+  Vertex tmp;
   Vertex block;
   Graph retval;
   retval = (Graph)malloc(sizeof(*retval));

--- a/src/Olden/mst/orig/mst.h
+++ b/src/Olden/mst/orig/mst.h
@@ -20,4 +20,3 @@ typedef struct graph_st {
 Graph MakeGraph(int numvert, int numproc);
 int dealwithargs(int argc, char *argv[]);
 
-int atoi(const char *);


### PR DESCRIPTION
Changed ptr to _Ptr etc., created multi-line decls (or collapsed them), removed unneeded prototypes.

Left behind: 
- problems due to local def of malloc
- inlining of macros in array decls