### PR TITLE
Spurious diffs in yacr2

### DIFF
--- a/src/Ptrdist/yacr2/manual/assign.c
+++ b/src/Ptrdist/yacr2/manual/assign.c
@@ -5,9 +5,6 @@
  */
 
 
-#define ASSIGN_CODE
-
-
 /*
  *
  * Includes.
@@ -22,6 +19,18 @@
 #include "channel.h"
 #include "vcg.h"
 #include "hcg.h"
+
+_Array_ptr<struct costMatrixRow>			costMatrix : count(channelNets + 1);
+_Array_ptr<ulong>			tracksNoHCV : count(channelTracks+2);
+_Array_ptr<ulong>			tracksNotPref : count(channelTracks+2);
+_Array_ptr<ulong>			tracksTopNotPref : count(channelTracks+2);
+_Array_ptr<ulong>			tracksBotNotPref : count(channelTracks+2);
+ulong				cardNotPref;
+ulong				cardTopNotPref;
+ulong				cardBotNotPref;
+_Array_ptr<ulong>			tracksAssign : count(channelTracks+2);
+_Array_ptr<ulong>			netsAssign : count(channelNets + 1);
+_Array_ptr<ulong>			netsAssignCopy : count(channelNets + 1);
 
 #pragma CHECKED_SCOPE ON
 #define printf(...) _Unchecked { (printf)(__VA_ARGS__); }
@@ -315,9 +324,7 @@ LeftNetsAssign(void)
 }
 
 void
-Assign(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-       _Array_ptr<ulong> assign : count(channelNets + 1),
-       ulong select)
+Assign(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),       _Array_ptr<ulong> assign : count(channelNets + 1),       ulong select)
 {
     long	dist;
     ulong	ideal;
@@ -510,11 +517,7 @@ Assign(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 }
 
 void
-Select(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-	_Array_ptr<nodeHCGType> HCG : count(channelNets + 1),
-	_Array_ptr<ulong> netsAssign : count(channelNets + 1),
-	_Ptr<ulong> netSelect,
-	_Array_ptr<ulong> CROSSING : count(channelNets + 1))
+Select(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),	_Array_ptr<nodeHCGType> HCG : count(channelNets + 1),	_Array_ptr<ulong> netsAssign : count(channelNets + 1),	_Ptr<ulong> netSelect,	_Array_ptr<ulong> CROSSING : count(channelNets + 1))
 {
     ulong	net;
     ulong	track;
@@ -556,10 +559,7 @@ Select(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 }
 
 void
-BuildCostMatrix(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-		_Array_ptr<nodeHCGType> HCG : count(channelNets + 1),
-		_Array_ptr<ulong> netsAssign : count(channelNets + 1),
-		_Array_ptr<ulong> CROSSING : count(channelNets + 1))
+BuildCostMatrix(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),		_Array_ptr<nodeHCGType> HCG : count(channelNets + 1),		_Array_ptr<ulong> netsAssign : count(channelNets + 1),		_Array_ptr<ulong> CROSSING : count(channelNets + 1))
 {
     ulong	net;
     ulong	track;
@@ -636,10 +636,7 @@ BuildCostMatrix(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 }
 
 void
-IdealTrack(ulong tracks,
-	   ulong top,
-	   ulong bot,
-	   _Ptr<ulong> ideal)
+IdealTrack(ulong tracks,	   ulong top,	   ulong bot,	   _Ptr<ulong> ideal)
 {
     ulong	num;
     ulong	den;

--- a/src/Ptrdist/yacr2/manual/assign.h
+++ b/src/Ptrdist/yacr2/manual/assign.h
@@ -52,22 +52,6 @@ struct costMatrixRow {
 extern ulong channelNets;
 extern ulong channelTracks;
 
-#ifdef ASSIGN_CODE
-
-_Array_ptr<struct costMatrixRow>			costMatrix : count(channelNets + 1);
-_Array_ptr<ulong>			tracksNoHCV : count(channelTracks+2);
-_Array_ptr<ulong>			tracksNotPref : count(channelTracks+2);
-_Array_ptr<ulong>			tracksTopNotPref : count(channelTracks+2);
-_Array_ptr<ulong>			tracksBotNotPref : count(channelTracks+2);
-ulong				cardNotPref;
-ulong				cardTopNotPref;
-ulong				cardBotNotPref;
-_Array_ptr<ulong>			tracksAssign : count(channelTracks+2);
-_Array_ptr<ulong>			netsAssign : count(channelNets + 1);
-_Array_ptr<ulong>			netsAssignCopy : count(channelNets + 1);
-
-#else	/* ASSIGN_CODE */
-
 extern _Array_ptr<struct costMatrixRow>			costMatrix : count(channelNets + 1); // 2dim, second dim is (channelTracks + 2)
 extern _Array_ptr<ulong>			tracksNoHCV : count(channelTracks+2);
 extern _Array_ptr<ulong>			tracksNotPref : count(channelTracks+2);
@@ -80,8 +64,6 @@ extern _Array_ptr<ulong>			tracksAssign : count(channelTracks+2);
 extern _Array_ptr<ulong>			netsAssign : count(channelNets + 1);
 extern _Array_ptr<ulong>			netsAssignCopy : count(channelNets + 1);
 
-#endif	/* ASSIGN_CODE */
-
 
 /*
  *
@@ -89,8 +71,6 @@ extern _Array_ptr<ulong>			netsAssignCopy : count(channelNets + 1);
  *
  */
 
-#ifdef ASSIGN_CODE
-
 void
 AllocAssign(void);
 
@@ -110,74 +90,16 @@ void
 LeftNetsAssign(void);
 
 void
-Assign(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-       _Array_ptr<ulong> : count(channelNets + 1),
-       ulong);
+Assign(_Array_ptr<nodeVCGType> : count(channelNets + 1),       _Array_ptr<ulong> : count(channelNets + 1),       ulong);
 
 void
-Select(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-       _Array_ptr<nodeHCGType> : count(channelNets + 1),
-       _Array_ptr<ulong> : count(channelNets + 1),
-       _Ptr<ulong>,
-       _Array_ptr<ulong> : count(channelNets + 1));
+Select(_Array_ptr<nodeVCGType> : count(channelNets + 1),       _Array_ptr<nodeHCGType> : count(channelNets + 1),       _Array_ptr<ulong> : count(channelNets + 1),       _Ptr<ulong>,       _Array_ptr<ulong> : count(channelNets + 1));
 
 void
-BuildCostMatrix(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-        _Array_ptr<nodeHCGType> : count(channelNets + 1),
-        _Array_ptr<ulong> : count(channelNets + 1),
-        _Array_ptr<ulong> : count(channelNets + 1));
+BuildCostMatrix(_Array_ptr<nodeVCGType> : count(channelNets + 1),        _Array_ptr<nodeHCGType> : count(channelNets + 1),        _Array_ptr<ulong> : count(channelNets + 1),        _Array_ptr<ulong> : count(channelNets + 1));
 
 void
-IdealTrack(ulong,
-	   ulong,
-	   ulong,
-	   _Ptr<ulong>);
-
-#else	/* ASSIGN_CODE */
-
-extern void
-AllocAssign(void);
-
-extern void
-FreeAssign(void);
-
-extern void
-NetsAssign(void);
-
-extern void
-MaxNetsAssign(void);
-
-extern void
-RightNetsAssign(void);
-
-extern void
-LeftNetsAssign(void);
-
-extern void
-Assign(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-       _Array_ptr<ulong> : count(channelNets + 1),
-       ulong);
-
-extern void
-Select(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-       _Array_ptr<nodeHCGType> : count(channelNets + 1),
-       _Array_ptr<ulong> : count(channelNets + 1),
-       _Ptr<ulong>,
-       _Array_ptr<ulong> : count(channelNets + 1));
-
-extern void
-BuildCostMatrix(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-        _Array_ptr<nodeHCGType> : count(channelNets + 1),
-        _Array_ptr<ulong> : count(channelNets + 1),
-        _Array_ptr<ulong> : count(channelNets + 1));
-
-extern void
-IdealTrack(ulong,
-	   ulong,
-	   ulong,
-	   _Ptr<ulong>);
-
-#endif	/* ASSIGN_CODE */
+IdealTrack(ulong,	   ulong,	   ulong,	   _Ptr<ulong>);
 
 #pragma CHECKED_SCOPE OFF
 #endif	/* ASSIGN_H */

--- a/src/Ptrdist/yacr2/manual/channel.c
+++ b/src/Ptrdist/yacr2/manual/channel.c
@@ -5,8 +5,6 @@
  */
 
 
-#define CHANNEL_CODE
-
 
 /*
  *
@@ -21,6 +19,22 @@
 
 #pragma CHECKED_SCOPE ON
 #define printf(...) _Unchecked { (printf)(__VA_ARGS__); }
+
+ulong			channelNets;
+ulong			channelColumns;
+_Array_ptr<ulong>		TOP : count(channelColumns + 1);
+_Array_ptr<ulong>		BOT : count(channelColumns + 1);
+_Array_ptr<ulong>		FIRST : count(channelNets + 1);
+_Array_ptr<ulong>		LAST : count(channelNets + 1);
+_Array_ptr<ulong>		DENSITY : count(channelColumns + 1);
+_Array_ptr<ulong>		CROSSING : count(channelNets + 1);
+ulong			channelTracks;
+ulong			channelTracksCopy;
+ulong			channelDensity;
+ulong			channelDensityColumn;
+_Nt_array_ptr<char> channelFile = ((void *)0);
+
+
 
 /*
  *

--- a/src/Ptrdist/yacr2/manual/channel.h
+++ b/src/Ptrdist/yacr2/manual/channel.h
@@ -40,24 +40,6 @@
  *
  */
 
-#ifdef CHANNEL_CODE
-
-ulong			channelNets;
-ulong			channelColumns;
-_Array_ptr<ulong>		TOP : count(channelColumns + 1);
-_Array_ptr<ulong>		BOT : count(channelColumns + 1);
-_Array_ptr<ulong>		FIRST : count(channelNets + 1);
-_Array_ptr<ulong>		LAST : count(channelNets + 1);
-_Array_ptr<ulong>		DENSITY : count(channelColumns + 1);
-_Array_ptr<ulong>		CROSSING : count(channelNets + 1);
-ulong			channelTracks;
-ulong			channelTracksCopy;
-ulong			channelDensity;
-ulong			channelDensityColumn;
-_Nt_array_ptr<char>		channelFile;
-
-#else	/* CHANNEL_CODE */
-
 extern ulong		channelNets;
 extern ulong		channelColumns;
 extern _Array_ptr<ulong>		TOP : count(channelColumns + 1);
@@ -72,8 +54,6 @@ extern ulong		channelDensity;
 extern ulong		channelDensityColumn;
 extern _Nt_array_ptr<char>		channelFile;
 
-#endif	/* CHANNEL_CODE */
-
 
 /*
  *
@@ -81,8 +61,6 @@ extern _Nt_array_ptr<char>		channelFile;
  *
  */
 
-#ifdef CHANNEL_CODE
-
 void
 BuildChannel(void);
 
@@ -94,22 +72,6 @@ DescribeChannel(void);
 
 void
 DensityChannel(void);
-
-#else	/* CHANNEL_CODE */
-
-extern void
-BuildChannel(void);
-
-extern void
-DimensionChannel(void);
-
-extern void
-DescribeChannel(void);
-
-extern void
-DensityChannel(void);
-
-#endif	/* CHANNEL_CODE */
 
 #pragma CHECKED_SCOPE OFF
 #endif	/* CHANNEL_H */

--- a/src/Ptrdist/yacr2/manual/hcg.c
+++ b/src/Ptrdist/yacr2/manual/hcg.c
@@ -5,8 +5,6 @@
  */
 
 
-#define HCG_CODE
-
 
 /*
  *
@@ -28,6 +26,11 @@
  * Code.
  *
  */
+
+_Array_ptr<nodeHCGType>			HCG : count(channelNets + 1);
+_Array_ptr<ulong>				storageRootHCG : count(channelNets + 1);
+_Array_ptr<ulong>				storageHCG : bounds(storageRootHCG, storageRootHCG + channelNets + 1);
+ulong					storageLimitHCG;
 
 void
 AllocHCG(void)
@@ -134,10 +137,7 @@ DumpHCG(_Array_ptr<nodeHCGType> HCG : count(channelNets + 1))
 }
 
 void
-NoHCV(_Array_ptr<nodeHCGType> HCG : count(channelNets + 1),
-      ulong select,
-      _Array_ptr<ulong> netsAssign : count(channelNets + 1),
-      _Array_ptr<ulong> tracksNoHCV : count(channelTracks + 2))
+NoHCV(_Array_ptr<nodeHCGType> HCG : count(channelNets + 1),      ulong select,      _Array_ptr<ulong> netsAssign : count(channelNets + 1),      _Array_ptr<ulong> tracksNoHCV : count(channelTracks + 2))
 {
     ulong	track;
     ulong	net;

--- a/src/Ptrdist/yacr2/manual/hcg.h
+++ b/src/Ptrdist/yacr2/manual/hcg.h
@@ -47,22 +47,10 @@ typedef struct _nodeHCGType {
 extern ulong channelNets;
 extern ulong channelTracks;
 
-#ifdef HCG_CODE
-
-_Array_ptr<nodeHCGType>			HCG : count(channelNets + 1);
-_Array_ptr<ulong>				storageRootHCG : count(channelNets + 1);
-_Array_ptr<ulong>				storageHCG : bounds(storageRootHCG, storageRootHCG + channelNets + 1);
-ulong					storageLimitHCG;
-
-#else	/* HCG_CODE */
-
 extern _Array_ptr<nodeHCGType>			HCG : count(channelNets + 1);
 extern _Array_ptr<ulong>			storageRootHCG : count(channelNets + 1);
 extern _Array_ptr<ulong>			storageHCG : bounds(storageRootHCG, storageRootHCG + channelNets + 1);
 extern ulong				storageLimitHCG;
-
-#endif	/* HCG_CODE */
-
 
 /*
  *
@@ -70,8 +58,6 @@ extern ulong				storageLimitHCG;
  *
  */
 
-#ifdef HCG_CODE
-
 void
 AllocHCG(void);
 
@@ -88,35 +74,7 @@ void
 DumpHCG(_Array_ptr<nodeHCGType> : count(channelNets + 1));
 
 void
-NoHCV(_Array_ptr<nodeHCGType> : count(channelNets + 1),
-      ulong,
-      _Array_ptr<ulong> : count(channelNets + 1),
-      _Array_ptr<ulong> : count(channelTracks + 2));
-
-#else	/* HCG_CODE */
-
-extern void
-AllocHCG(void);
-
-extern void
-FreeHCG(void);
-
-extern void
-BuildHCG(void);
-
-extern void
-DFSClearHCG(_Array_ptr<nodeHCGType> : count(channelNets + 1));
-
-extern void
-DumpHCG(_Array_ptr<nodeHCGType> : count(channelNets + 1));
-
-extern void
-NoHCV(_Array_ptr<nodeHCGType> : count(channelNets + 1),
-      ulong,
-      _Array_ptr<ulong> : count(channelNets + 1),
-      _Array_ptr<ulong> : count(channelTracks + 2));
-
-#endif	/* HCG_CODE */
+NoHCV(_Array_ptr<nodeHCGType> : count(channelNets + 1),      ulong,      _Array_ptr<ulong> : count(channelNets + 1),      _Array_ptr<ulong> : count(channelTracks + 2));
 
 #pragma CHECKED_SCOPE OFF
 #endif	/* HCG_H */

--- a/src/Ptrdist/yacr2/manual/main.c
+++ b/src/Ptrdist/yacr2/manual/main.c
@@ -35,8 +35,7 @@
  */
 
 int
-main(int argc,
-     _Array_ptr<_Nt_array_ptr<char>> argv : count(argc))
+main(int argc, _Array_ptr<_Nt_array_ptr<char>> argv : count(argc))
 {
     ulong      	done;
     ulong	fail;

--- a/src/Ptrdist/yacr2/manual/maze.c
+++ b/src/Ptrdist/yacr2/manual/maze.c
@@ -14,9 +14,6 @@
 #define min(a,b)	((a<b) ? a : b)
 #define max(a,b)	((a<b) ? b : a)
 
-#undef bzero
-void bzero(void * : byte_count(n), size_t n);
-
 /*
  *	plane allocation structures and routines
  */
@@ -89,9 +86,7 @@ FreeAllocMaps(void)
  *	they are sorted as needed by the line drawer
  */
 void
-DrawSegment(_Array_ptr<char> plane : count((channelColumns+1)*(channelTracks+2)),
-	    unsigned long x1, unsigned long y1,
-	    unsigned long x2, unsigned long y2)
+DrawSegment(_Array_ptr<char> plane : count((channelColumns+1)*(channelTracks+2)),	    unsigned long x1, unsigned long y1,	    unsigned long x2, unsigned long y2)
 {
     unsigned long x, y;
 
@@ -163,9 +158,7 @@ HasVia(unsigned long x, unsigned long y)
  *	they are sorted as needed by the line drawer
  */
 int
-SegmentFree(_Array_ptr<char> plane : count((channelColumns+1)*(channelTracks+2)),
-	    unsigned long x1, unsigned long y1,
-	    unsigned long x2, unsigned long y2)
+SegmentFree(_Array_ptr<char> plane : count((channelColumns+1)*(channelTracks+2)),	    unsigned long x1, unsigned long y1,	    unsigned long x2, unsigned long y2)
 {
     unsigned long x, y;
     unsigned long index;
@@ -318,13 +311,13 @@ DrawNets(void)
     int numLeft = 0;
 
     /* initialize maps to empty */
-    _Unchecked { bzero(horzPlane,
+    _Unchecked { memset(horzPlane, '\0',
 	  (int)((channelColumns+1)*(channelTracks+2))); }
-    _Unchecked { bzero(vertPlane,
+    _Unchecked { memset(vertPlane, '\0',
 	  (int)((channelColumns+1)*(channelTracks+2))); }
-    _Unchecked { bzero(viaPlane,
+    _Unchecked { memset(viaPlane, '\0',
 	  (int)((channelColumns+1)*(channelTracks+2))); }
-    _Unchecked { bzero(mazeRoute,
+    _Unchecked { memset(mazeRoute, '\0',
 	  (int)(channelColumns+1)); }
 
     /* draw all horizontal segments */
@@ -650,9 +643,7 @@ Maze1(void)
  * can this track be extended to the range specified, return result
  */
 int
-ExtendOK(unsigned long net, _Array_ptr<char> plane : count((channelColumns + 1)*(channelTracks + 3)),
-	 unsigned long _x1, unsigned long _y1,	/* start seg */
-	 unsigned long _x2, unsigned long _y2)	/* end seg */
+ExtendOK(unsigned long net, _Array_ptr<char> plane : count((channelColumns + 1)*(channelTracks + 3)),	 unsigned long _x1, unsigned long _y1,	/* start seg */	 unsigned long _x2, unsigned long _y2)	/* end seg */
 {
     unsigned long x1, y1, x2, y2;
 
@@ -883,8 +874,7 @@ Maze2(void)
 
 
 void
-FindFreeHorzSeg(unsigned long startCol, unsigned long row,
-		_Ptr<unsigned long> rowStart, _Ptr<unsigned long> rowEnd)
+FindFreeHorzSeg(unsigned long startCol, unsigned long row,		_Ptr<unsigned long> rowStart, _Ptr<unsigned long> rowEnd)
 {
     unsigned long i;
 

--- a/src/Ptrdist/yacr2/manual/option.c
+++ b/src/Ptrdist/yacr2/manual/option.c
@@ -7,8 +7,6 @@
 
 #include <string.h>
 
-#define OPTION_CODE
-
 
 /*
  *
@@ -30,8 +28,7 @@
  */
 
 void
-Option(int argc,
-       _Array_ptr<_Nt_array_ptr<char>> argv : count(argc))
+Option(int argc, _Array_ptr<_Nt_array_ptr<char>> argv : count(argc))
 {
     /*
      * Check arguments.

--- a/src/Ptrdist/yacr2/manual/option.h
+++ b/src/Ptrdist/yacr2/manual/option.h
@@ -37,32 +37,14 @@
  *
  */
 
-#ifdef OPTION_CODE
-
-#else	/* OPTION_CODE */
-
-#endif	/* OPTION_CODE */
-
-
 /*
  *
  * Prototypes.
  *
  */
 
-#ifdef OPTION_CODE
-
 void
-Option(int argc,
-       _Array_ptr<_Nt_array_ptr<char>> : count(argc));
-
-#else	/* OPTION_CODE */
-
-extern void
-Option(int argc,
-       _Array_ptr<_Nt_array_ptr<char>> : count(argc));
-
-#endif	/* OPTION_CODE */
+Option(int argc, _Array_ptr<_Nt_array_ptr<char>> argv : count(argc));
 
 #pragma CHECKED_SCOPE OFF
 #endif	/* OPTION_H */

--- a/src/Ptrdist/yacr2/manual/vcg.c
+++ b/src/Ptrdist/yacr2/manual/vcg.c
@@ -6,8 +6,6 @@
  */
 
 
-#define VCG_CODE
-
 
 /*
  *
@@ -25,6 +23,16 @@
 
 #pragma CHECKED_SCOPE ON
 #define printf(...) _Unchecked { (printf)(__VA_ARGS__); }
+
+_Array_ptr<nodeVCGType>			VCG : count(channelNets + 1);
+_Array_ptr<constraintVCGType>			storageRootVCG : count((channelNets + 1) * (channelNets + 1));
+_Array_ptr<constraintVCGType>			storageVCG : bounds(storageRootVCG, storageRootVCG + (channelNets + 1) * (channelNets + 1));
+ulong					storageLimitVCG;
+_Array_ptr<_Ptr<constraintVCGType>>		removeVCG : count((channelNets + 1) * (channelNets + 1));
+ulong					removeTotalVCG;
+_Array_ptr<ulong>				SCC : count(channelNets + 1);
+ulong					totalSCC;
+_Array_ptr<ulong>				perSCC : count(channelNets + 1);
 
 /*
  *
@@ -147,8 +155,7 @@ BuildVCG(void)
     }
 }
 
-void
-DFSClearVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1))
+void DFSClearVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1))
 {
     ulong	net;
 
@@ -160,8 +167,7 @@ DFSClearVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1))
     }	
 }
 
-void
-DumpVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1))
+void DumpVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1))
 {
     ulong	net;
     ulong	which;
@@ -188,9 +194,7 @@ DumpVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1))
     }	
 }
 
-void
-DFSAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-	    ulong net)
+void DFSAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),	    ulong net)
 {
     ulong	s;
     ulong 	above;
@@ -207,9 +211,7 @@ DFSAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     }
 }
 
-void
-DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-	    ulong net)
+void DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),	    ulong net)
 {
     ulong	s;
     ulong 	below;
@@ -226,11 +228,7 @@ DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     }
 }
 
-void
-SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-	     _Array_ptr<ulong> SCC : count(channelNets + 1),
-		 _Array_ptr<ulong> perSCC : count(countSCC + 1),
-		 ulong countSCC)
+void SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),	     _Array_ptr<ulong> SCC : count(channelNets + 1),		 _Array_ptr<ulong> perSCC : count(countSCC + 1),		 ulong countSCC)
 {
     ulong      	net;
     ulong      	scc;
@@ -307,10 +305,7 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ;
 }
 
-void
-SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-		ulong net,
-		_Ptr<ulong> label)
+void SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),		ulong net,		_Ptr<ulong> label)
 {
     ulong	s;
     ulong 	above;
@@ -329,10 +324,7 @@ SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     VCG[net].netsAboveLabel = *label;
 }
 
-void
-SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-		ulong net,
-		ulong label)
+void SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),		ulong net,		ulong label)
 {
     ulong	s;
     ulong 	below;
@@ -350,9 +342,7 @@ SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     VCG[net].netsBelowLabel = label;
 }
 
-void
-DumpSCC(_Array_ptr<ulong> SCC : count(channelNets + 1),
-		_Array_ptr<ulong> perSCC : count(totalSCC + 1))
+void DumpSCC(_Array_ptr<ulong> SCC : count(channelNets + 1),		_Array_ptr<ulong> perSCC : count(totalSCC + 1))
 {
     ulong	net;
     ulong	scc;
@@ -502,11 +492,7 @@ AcyclicVCG(void)
     }
 }
 
-void
-RemoveConstraintVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-					_Array_ptr<ulong> SCC : count(channelNets + 1),
-					_Array_ptr<ulong> perSCC : count(channelNets + 1),
-		            _Array_ptr<_Ptr<constraintVCGType>> removeVCG : count((channelNets + 1) * (channelNets + 1)))
+void RemoveConstraintVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),					_Array_ptr<ulong> SCC : count(channelNets + 1),					_Array_ptr<ulong> perSCC : count(channelNets + 1),		            _Array_ptr<_Ptr<constraintVCGType>> removeVCG : count((channelNets + 1) * (channelNets + 1)))
 {
     ulong			scc;
     ulong			net;
@@ -642,19 +628,14 @@ RemoveConstraintVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     }
 }
 
-ulong
-ExistPathAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-		  ulong above,
-		  ulong below)
+ulong ExistPathAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),		  ulong above,		  ulong below)
 {
     DFSClearVCG(VCG);
     DFSAboveVCG(VCG, above);
     return(VCG[below].netsAboveReached);
 }
 
-void
-LongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-	       ulong net)
+void LongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),	       ulong net)
 {
     ulong	track;
     ulong	bot;
@@ -716,9 +697,7 @@ LongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     cardNotPref = not;
 }
 
-ulong
-DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-		       ulong net)
+ulong DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),		       ulong net)
 {
     ulong	s;
     ulong 	above;
@@ -742,9 +721,7 @@ DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     return(longest+1);
 }
 
-ulong
-DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-		       ulong net)
+ulong DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),		       ulong net)
 {
     ulong	s;
     ulong 	below;
@@ -768,11 +745,7 @@ DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     return(longest+1);
 }
 
-ulong
-VCV(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
-    ulong check,
-    ulong track,
-    _Array_ptr<ulong> assign : count(channelNets + 1))
+ulong VCV(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),    ulong check,    ulong track,    _Array_ptr<ulong> assign : count(channelNets + 1))
 {
     ulong	net;
     ulong	vcv;

--- a/src/Ptrdist/yacr2/manual/vcg.h
+++ b/src/Ptrdist/yacr2/manual/vcg.h
@@ -66,20 +66,6 @@ typedef struct _nodeVCGType {
 
 extern ulong channelNets;
 
-#ifdef VCG_CODE
-
-_Array_ptr<nodeVCGType>			VCG : count(channelNets + 1);
-_Array_ptr<constraintVCGType>			storageRootVCG : count((channelNets + 1) * (channelNets + 1));
-_Array_ptr<constraintVCGType>			storageVCG : bounds(storageRootVCG, storageRootVCG + (channelNets + 1) * (channelNets + 1));
-ulong					storageLimitVCG;
-_Array_ptr<_Ptr<constraintVCGType>>		removeVCG : count((channelNets + 1) * (channelNets + 1));
-ulong					removeTotalVCG;
-_Array_ptr<ulong>				SCC : count(channelNets + 1);
-ulong					totalSCC;
-_Array_ptr<ulong>				perSCC : count(channelNets + 1);
-
-#else	/* VCG_CODE */
-
 extern _Array_ptr<nodeVCGType>			VCG : count(channelNets + 1);
 extern _Array_ptr<constraintVCGType>			storageRootVCG : count((channelNets + 1) * (channelNets + 1));
 extern _Array_ptr<constraintVCGType>			storageVCG : bounds(storageRootVCG, storageRootVCG + (channelNets + 1) * (channelNets + 1));
@@ -90,8 +76,6 @@ extern _Array_ptr<ulong>				SCC : count(channelNets + 1);
 extern ulong					totalSCC;
 extern _Array_ptr<ulong>				perSCC : count(channelNets + 1);
 
-#endif	/* VCG_CODE */
-
 
 /*
  *
@@ -99,8 +83,6 @@ extern _Array_ptr<ulong>				perSCC : count(channelNets + 1);
  *
  */
 
-#ifdef VCG_CODE
-
 void
 AllocVCG(void);
 
@@ -110,150 +92,37 @@ FreeVCG(void);
 void
 BuildVCG(void);
 
-void
-DFSClearVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
+void DFSClearVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
 
-void
-DumpVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
+void DumpVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
 
-void
-DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-	    ulong);
+void DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),	    ulong);
 
-void
-DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-	    ulong);
+void DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),	    ulong);
 
-void
-SCCofVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		 _Array_ptr<ulong> : count(channelNets + 1),
-		 _Array_ptr<ulong> : count(countSCC + 1),
-		 ulong countSCC);
+void SCCofVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),		 _Array_ptr<ulong> : count(channelNets + 1),		 _Array_ptr<ulong> : count(countSCC + 1),		 ulong countSCC);
 
-void
-SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-				ulong,
-				_Ptr<ulong>);
+void SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),				ulong,				_Ptr<ulong>);
 
-void
-SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		ulong,
-		ulong);
+void SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),		ulong,		ulong);
 
-void
-DumpSCC(_Array_ptr<ulong> : count(channelNets + 1),
-	    _Array_ptr<ulong> : count(totalSCC + 1));
+void DumpSCC(_Array_ptr<ulong> : count(channelNets + 1),	    _Array_ptr<ulong> : count(totalSCC + 1));
 
 void
 AcyclicVCG(void);
 
-void
-RemoveConstraintVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-					_Array_ptr<ulong> : count(channelNets + 1),
-					_Array_ptr<ulong> : count(channelNets + 1),
-					_Array_ptr<_Ptr<constraintVCGType>> : count((channelNets + 1) * (channelNets + 1)));
+void RemoveConstraintVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),					_Array_ptr<ulong> : count(channelNets + 1),					_Array_ptr<ulong> : count(channelNets + 1),					_Array_ptr<_Ptr<constraintVCGType>> : count((channelNets + 1) * (channelNets + 1)));
 
-ulong
-ExistPathAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-				  ulong above,
-				  ulong below);
+ulong ExistPathAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),				  ulong above,				  ulong below);
 
-void
-LongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-	       ulong);
+void LongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),	       ulong);
 
-ulong
-DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		       ulong);
+ulong DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),		       ulong);
 
-ulong
-DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		       ulong);
+ulong DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),		       ulong);
 
-ulong
-VCV(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-    ulong,
-    ulong,
-    _Array_ptr<ulong> : count(channelNets + 1));
+ulong VCV(_Array_ptr<nodeVCGType> : count(channelNets + 1),    ulong,    ulong,    _Array_ptr<ulong> : count(channelNets + 1));
 
-#else	/* VCG_CODE */
-
-extern void
-AllocVCG(void);
-
-extern void
-FreeVCG(void);
-
-extern void
-BuildVCG(void);
-
-extern void
-DFSClearVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
-
-extern void
-DumpVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
-
-extern void
-DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-	    ulong);
-
-extern void
-DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-	    ulong);
-
-extern void
-SCCofVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		 _Array_ptr<ulong> : count(channelNets + 1),
-		 _Array_ptr<ulong> : count(countSCC + 1),
-		 ulong countSCC);
-
-extern void
-SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-				ulong,
-				_Ptr<ulong>);
-
-extern void
-SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		ulong,
-		ulong);
-
-extern void
-DumpSCC(_Array_ptr<ulong> : count(channelNets + 1),
-		_Array_ptr<ulong> : count(totalSCC + 1));
-
-extern void
-AcyclicVCG(void);
-
-extern void
-RemoveConstraintVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-					_Array_ptr<ulong> : count(channelNets + 1),
-					_Array_ptr<ulong> : count(channelNets + 1),
-					_Array_ptr<_Ptr<constraintVCGType>> : count((channelNets + 1) * (channelNets + 1)));
-
-extern ulong
-ExistPathAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		  ulong,
-		  ulong);
-
-extern void
-LongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-	       ulong);
-
-extern ulong
-DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		       ulong);
-
-extern ulong
-DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-		       ulong);
-
-extern ulong
-VCV(_Array_ptr<nodeVCGType> : count(channelNets + 1),
-	ulong,
-	ulong,
-	_Array_ptr<ulong> : count(channelNets + 1));
-
-#endif	/* VCG_CODE */
 
 #pragma CHECKED_SCOPE OFF
 #endif	/* VCG_H */

--- a/src/Ptrdist/yacr2/orig/assign.c
+++ b/src/Ptrdist/yacr2/orig/assign.c
@@ -5,9 +5,6 @@
  */
 
 
-#define ASSIGN_CODE
-
-
 /*
  *
  * Includes.
@@ -22,6 +19,18 @@
 #include "channel.h"
 #include "vcg.h"
 #include "hcg.h"
+
+long * *			costMatrix;
+ulong *			tracksNoHCV;
+ulong *			tracksNotPref;
+ulong *			tracksTopNotPref;
+ulong *			tracksBotNotPref;
+ulong				cardNotPref;
+ulong				cardTopNotPref;
+ulong				cardBotNotPref;
+ulong *			tracksAssign;
+ulong *			netsAssign;
+ulong *			netsAssignCopy;
 
 
 /*
@@ -312,9 +321,7 @@ LeftNetsAssign(void)
 }
 
 void
-Assign(nodeVCGType * VCG,
-       ulong * assign,
-       ulong select)
+Assign(nodeVCGType * VCG, ulong * assign, ulong select)
 {
     long	dist;
     ulong	ideal;
@@ -507,11 +514,7 @@ Assign(nodeVCGType * VCG,
 }
 
 void
-Select(nodeVCGType * VCG,
-       nodeHCGType * HCG,
-       ulong * netsAssign,
-       ulong * netSelect,
-       ulong * CROSSING)
+Select(nodeVCGType * VCG, nodeHCGType * HCG, ulong * netsAssign, ulong * netSelect, ulong * CROSSING)
 {
     ulong	net;
     ulong	track;
@@ -553,10 +556,7 @@ Select(nodeVCGType * VCG,
 }
 
 void
-BuildCostMatrix(nodeVCGType * VCG,
-		nodeHCGType * HCG,
-		ulong * netsAssign,
-		ulong * CROSSING)
+BuildCostMatrix(nodeVCGType * VCG, nodeHCGType * HCG, ulong * netsAssign, ulong * CROSSING)
 {
     ulong	net;
     ulong	track;
@@ -633,10 +633,7 @@ BuildCostMatrix(nodeVCGType * VCG,
 }
 
 void
-IdealTrack(ulong tracks,
-	   ulong top,
-	   ulong bot,
-	   ulong * ideal)
+IdealTrack(ulong tracks, ulong top, ulong bot, ulong * ideal)
 {
     ulong	num;
     ulong	den;

--- a/src/Ptrdist/yacr2/orig/assign.h
+++ b/src/Ptrdist/yacr2/orig/assign.h
@@ -44,22 +44,6 @@
  *
  */
 
-#ifdef ASSIGN_CODE
-
-long * *			costMatrix;
-ulong *			tracksNoHCV;
-ulong *			tracksNotPref;
-ulong *			tracksTopNotPref;
-ulong *			tracksBotNotPref;
-ulong				cardNotPref;
-ulong				cardTopNotPref;
-ulong				cardBotNotPref;
-ulong *			tracksAssign;
-ulong *			netsAssign;
-ulong *			netsAssignCopy;
-
-#else	/* ASSIGN_CODE */
-
 extern ulong * *		costMatrix;
 extern ulong *		tracksNoHCV;
 extern ulong *		tracksNotPref;
@@ -72,8 +56,6 @@ extern ulong *		tracksAssign;
 extern ulong *		netsAssign;
 extern ulong *		netsAssignCopy;
 
-#endif	/* ASSIGN_CODE */
-
 
 /*
  *
@@ -81,8 +63,6 @@ extern ulong *		netsAssignCopy;
  *
  */
 
-#ifdef ASSIGN_CODE
-
 void
 AllocAssign(void);
 
@@ -102,74 +82,17 @@ void
 LeftNetsAssign(void);
 
 void
-Assign(nodeVCGType *,
-       ulong *,
-       ulong);
+Assign(nodeVCGType *,       ulong *,       ulong);
 
 void
-Select(nodeVCGType *,
-       nodeHCGType *,
-       ulong *,
-       ulong *,
-       ulong *);
+Select(nodeVCGType *,       nodeHCGType *,       ulong *,       ulong *,       ulong *);
 
 void
-BuildCostMatrix(nodeVCGType *,
-		nodeHCGType *,
-		ulong *,
-		ulong *);
+BuildCostMatrix(nodeVCGType *,		nodeHCGType *,		ulong *,		ulong *);
 
 void
-IdealTrack(ulong,
-	   ulong,
-	   ulong,
-	   ulong *);
+IdealTrack(ulong tracks, ulong top, ulong bot, ulong * ideal);
 
-#else	/* ASSIGN_CODE */
-
-extern void
-AllocAssign(void);
-
-extern void
-FreeAssign(void);
-
-extern void
-NetsAssign(void);
-
-extern void
-MaxNetsAssign(void);
-
-extern void
-RightNetsAssign(void);
-
-extern void
-LeftNetsAssign(void);
-
-extern void
-Assign(nodeVCGType *,
-       ulong *,
-       ulong);
-
-extern void
-Select(nodeVCGType *,
-       nodeHCGType *,
-       ulong *,
-       ulong *,
-       ulong *);
-
-extern void
-BuildCostMatrix(nodeVCGType *,
-		nodeHCGType *,
-		ulong *,
-		ulong *);
-
-extern void
-IdealTrack(ulong,
-	   ulong,
-	   ulong,
-	   ulong *);
-
-#endif	/* ASSIGN_CODE */
 
 #endif	/* ASSIGN_H */
 

--- a/src/Ptrdist/yacr2/orig/channel.c
+++ b/src/Ptrdist/yacr2/orig/channel.c
@@ -5,8 +5,6 @@
  */
 
 
-#define CHANNEL_CODE
-
 
 /*
  *
@@ -18,6 +16,20 @@
 #include <stdlib.h>
 #include "types.h"
 #include "channel.h"
+
+ulong *		TOP;
+ulong *		BOT;
+ulong *		FIRST;
+ulong *		LAST;
+ulong *		DENSITY;
+ulong *		CROSSING;
+ulong			channelNets;
+ulong			channelColumns;
+ulong			channelTracks;
+ulong			channelTracksCopy;
+ulong			channelDensity;
+ulong			channelDensityColumn;
+char *		channelFile;
 
 
 /*

--- a/src/Ptrdist/yacr2/orig/channel.h
+++ b/src/Ptrdist/yacr2/orig/channel.h
@@ -39,24 +39,6 @@
  *
  */
 
-#ifdef CHANNEL_CODE
-
-ulong *		TOP;
-ulong *		BOT;
-ulong *		FIRST;
-ulong *		LAST;
-ulong *		DENSITY;
-ulong *		CROSSING;
-ulong			channelNets;
-ulong			channelColumns;
-ulong			channelTracks;
-ulong			channelTracksCopy;
-ulong			channelDensity;
-ulong			channelDensityColumn;
-char *		channelFile;
-
-#else	/* CHANNEL_CODE */
-
 extern ulong *	TOP;
 extern ulong *	BOT;
 extern ulong *	FIRST;
@@ -71,17 +53,12 @@ extern ulong		channelDensity;
 extern ulong		channelDensityColumn;
 extern char *	channelFile;
 
-#endif	/* CHANNEL_CODE */
-
-
 /*
  *
  * Prototypes.
  *
  */
 
-#ifdef CHANNEL_CODE
-
 void
 BuildChannel(void);
 
@@ -93,21 +70,5 @@ DescribeChannel(void);
 
 void
 DensityChannel(void);
-
-#else	/* CHANNEL_CODE */
-
-extern void
-BuildChannel(void);
-
-extern void
-DimensionChannel(void);
-
-extern void
-DescribeChannel(void);
-
-extern void
-DensityChannel(void);
-
-#endif	/* CHANNEL_CODE */
 
 #endif	/* CHANNEL_H */

--- a/src/Ptrdist/yacr2/orig/hcg.c
+++ b/src/Ptrdist/yacr2/orig/hcg.c
@@ -5,8 +5,6 @@
  */
 
 
-#define HCG_CODE
-
 
 /*
  *
@@ -20,6 +18,11 @@
 #include "types.h"
 #include "hcg.h"
 #include "channel.h"
+
+nodeHCGType *			HCG;
+ulong *				storageRootHCG;
+ulong *				storageHCG;
+ulong					storageLimitHCG;
 
 
 /*
@@ -131,10 +134,7 @@ DumpHCG(nodeHCGType * HCG)
 }
 
 void
-NoHCV(nodeHCGType * HCG,
-      ulong select,
-      ulong * netsAssign,
-      ulong * tracksNoHCV)
+NoHCV(nodeHCGType * HCG,      ulong select,      ulong * netsAssign,      ulong * tracksNoHCV)
 {
     ulong	track;
     ulong	net;

--- a/src/Ptrdist/yacr2/orig/hcg.h
+++ b/src/Ptrdist/yacr2/orig/hcg.h
@@ -43,21 +43,10 @@ typedef struct _nodeHCGType {
  *
  */
 
-#ifdef HCG_CODE
-
-nodeHCGType *			HCG;
-ulong *				storageRootHCG;
-ulong *				storageHCG;
-ulong					storageLimitHCG;
-
-#else	/* HCG_CODE */
-
 extern nodeHCGType *			HCG;
 extern ulong *			storageRootHCG;
 extern ulong *			storageHCG;
 extern ulong				storageLimitHCG;
-
-#endif	/* HCG_CODE */
 
 
 /*
@@ -66,8 +55,6 @@ extern ulong				storageLimitHCG;
  *
  */
 
-#ifdef HCG_CODE
-
 void
 AllocHCG(void);
 
@@ -84,34 +71,6 @@ void
 DumpHCG(nodeHCGType *);
 
 void
-NoHCV(nodeHCGType *,
-      ulong,
-      ulong *,
-      ulong *);
-
-#else	/* HCG_CODE */
-
-extern void
-AllocHCG(void);
-
-extern void
-FreeHCG(void);
-
-extern void
-BuildHCG(void);
-
-extern void
-DFSClearHCG(nodeHCGType *);
-
-extern void
-DumpHCG(nodeHCGType *);
-
-extern void
-NoHCV(nodeHCGType *,
-      ulong,
-      ulong *,
-      ulong *);
-
-#endif	/* HCG_CODE */
+NoHCV(nodeHCGType *,      ulong,      ulong *,      ulong *);
 
 #endif	/* HCG_H */

--- a/src/Ptrdist/yacr2/orig/maze.c
+++ b/src/Ptrdist/yacr2/orig/maze.c
@@ -84,9 +84,7 @@ FreeAllocMaps(void)
  *	they are sorted as needed by the line drawer
  */
 void
-DrawSegment(char * plane,
-	    unsigned long x1, unsigned long y1,
-	    unsigned long x2, unsigned long y2)
+DrawSegment(char * plane,	    unsigned long x1, unsigned long y1,	    unsigned long x2, unsigned long y2)
 {
     unsigned long x, y;
 
@@ -158,9 +156,7 @@ HasVia(unsigned long x, unsigned long y)
  *	they are sorted as needed by the line drawer
  */
 int
-SegmentFree(char * plane,
-	    unsigned long x1, unsigned long y1,
-	    unsigned long x2, unsigned long y2)
+SegmentFree(char * plane,	    unsigned long x1, unsigned long y1,	    unsigned long x2, unsigned long y2)
 {
     unsigned long x, y;
     unsigned long index;
@@ -313,13 +309,13 @@ DrawNets(void)
     int numLeft = 0;
 
     /* initialize maps to empty */
-    bzero(horzPlane,
+    memset(horzPlane, '\0',
 	  (int)((channelColumns+1)*(channelTracks+2)));
-    bzero(vertPlane,
+    memset(vertPlane, '\0', 
 	  (int)((channelColumns+1)*(channelTracks+2)));
-    bzero(viaPlane,
+    memset(viaPlane, '\0',
 	  (int)((channelColumns+1)*(channelTracks+2)));
-    bzero(mazeRoute,
+    memset(mazeRoute, '\0',
 	  (int)(channelColumns+1));
 
     /* draw all horizontal segments */
@@ -645,9 +641,7 @@ Maze1(void)
  * can this track be extended to the range specified, return result
  */
 int
-ExtendOK(unsigned long net, char * plane,
-	 unsigned long _x1, unsigned long _y1,	/* start seg */
-	 unsigned long _x2, unsigned long _y2)	/* end seg */
+ExtendOK(unsigned long net, char * plane,	 unsigned long _x1, unsigned long _y1,	/* start seg */	 unsigned long _x2, unsigned long _y2)	/* end seg */
 {
     unsigned long x1, y1, x2, y2;
 
@@ -878,8 +872,7 @@ Maze2(void)
 
 
 void
-FindFreeHorzSeg(unsigned long startCol, unsigned long row,
-		unsigned long * rowStart, unsigned long * rowEnd)
+FindFreeHorzSeg(unsigned long startCol, unsigned long row,		unsigned long * rowStart, unsigned long * rowEnd)
 {
     unsigned long i;
 

--- a/src/Ptrdist/yacr2/orig/option.c
+++ b/src/Ptrdist/yacr2/orig/option.c
@@ -7,8 +7,6 @@
 
 #include <string.h>
 
-#define OPTION_CODE
-
 
 /*
  *
@@ -28,8 +26,7 @@
  */
 
 void
-Option(int argc,
-       char *argv[])
+Option(int argc, char *argv[])
 {
     /*
      * Check arguments.

--- a/src/Ptrdist/yacr2/orig/option.h
+++ b/src/Ptrdist/yacr2/orig/option.h
@@ -36,31 +36,13 @@
  *
  */
 
-#ifdef OPTION_CODE
-
-#else	/* OPTION_CODE */
-
-#endif	/* OPTION_CODE */
-
-
 /*
  *
  * Prototypes.
  *
  */
 
-#ifdef OPTION_CODE
-
 void
-Option(int,
-       char (*[]));
-
-#else	/* OPTION_CODE */
-
-extern void
-Option(int,
-       char (*[]));
-
-#endif	/* OPTION_CODE */
+Option(int argc, char *argv[]);
 
 #endif	/* OPTION_H */

--- a/src/Ptrdist/yacr2/orig/vcg.c
+++ b/src/Ptrdist/yacr2/orig/vcg.c
@@ -6,8 +6,6 @@
  */
 
 
-#define VCG_CODE
-
 
 /*
  *
@@ -22,6 +20,17 @@
 #include "vcg.h"
 #include "assign.h"
 #include "channel.h"
+
+nodeVCGType *			VCG;
+constraintVCGType *			storageRootVCG;
+constraintVCGType *			storageVCG;
+ulong					storageLimitVCG;
+constraintVCGType * *		removeVCG;
+ulong					removeTotalVCG;
+ulong *				SCC;
+ulong					totalSCC;
+ulong *				perSCC;
+
 
 
 /*
@@ -143,8 +152,7 @@ BuildVCG(void)
     }
 }
 
-void
-DFSClearVCG(nodeVCGType * VCG)
+void DFSClearVCG(nodeVCGType * VCG)
 {
     ulong	net;
 
@@ -156,8 +164,7 @@ DFSClearVCG(nodeVCGType * VCG)
     }	
 }
 
-void
-DumpVCG(nodeVCGType * VCG)
+void DumpVCG(nodeVCGType * VCG)
 {
     ulong	net;
     ulong	which;
@@ -184,9 +191,7 @@ DumpVCG(nodeVCGType * VCG)
     }	
 }
 
-void
-DFSAboveVCG(nodeVCGType * VCG,
-	    ulong net)
+void DFSAboveVCG(nodeVCGType * VCG,	    ulong net)
 {
     ulong	s;
     ulong 	above;
@@ -203,9 +208,7 @@ DFSAboveVCG(nodeVCGType * VCG,
     }
 }
 
-void
-DFSBelowVCG(nodeVCGType * VCG,
-	    ulong net)
+void DFSBelowVCG(nodeVCGType * VCG,	    ulong net)
 {
     ulong	s;
     ulong 	below;
@@ -222,10 +225,7 @@ DFSBelowVCG(nodeVCGType * VCG,
     }
 }
 
-void
-SCCofVCG(nodeVCGType * VCG,
-	 ulong * SCC,
-	 ulong * perSCC)
+void SCCofVCG(nodeVCGType * VCG,	 ulong * SCC,	 ulong * perSCC)
 {
     ulong      	net;
     ulong      	scc;
@@ -302,10 +302,7 @@ SCCofVCG(nodeVCGType * VCG,
     ;
 }
 
-void
-SCC_DFSAboveVCG(nodeVCGType * VCG,
-		ulong net,
-		ulong * label)
+void SCC_DFSAboveVCG(nodeVCGType * VCG,		ulong net,		ulong * label)
 {
     ulong	s;
     ulong 	above;
@@ -324,10 +321,7 @@ SCC_DFSAboveVCG(nodeVCGType * VCG,
     VCG[net].netsAboveLabel = *label;
 }
 
-void
-SCC_DFSBelowVCG(nodeVCGType * VCG,
-		ulong net,
-		ulong label)
+void SCC_DFSBelowVCG(nodeVCGType * VCG,		ulong net,		ulong label)
 {
     ulong	s;
     ulong 	below;
@@ -345,9 +339,7 @@ SCC_DFSBelowVCG(nodeVCGType * VCG,
     VCG[net].netsBelowLabel = label;
 }
 
-void
-DumpSCC(ulong * SCC,
-	ulong * perSCC)
+void DumpSCC(ulong * SCC,	ulong * perSCC)
 {
     ulong	net;
     ulong	scc;
@@ -466,7 +458,7 @@ AcyclicVCG(void)
 	     * Introduces cycle.
 	     * Remove constraint (again).
 	     */
-	    for (which = 0; which < VCG[top].netsAbove; which++) {
+    for (which = 0; which < VCG[top].netsAbove; which++) {
 		if (VCG[top].netsAboveHook[which].bot == bot) {
 		    VCG[top].netsAboveHook[which].removed = TRUE;
 		    break;
@@ -497,11 +489,7 @@ AcyclicVCG(void)
     }
 }
 
-void
-RemoveConstraintVCG(nodeVCGType * VCG,
-		    ulong * SCC,
-		    ulong * perSCC,
-		    constraintVCGType * * removeVCG)
+void RemoveConstraintVCG(nodeVCGType * VCG,		    ulong * SCC,		    ulong * perSCC,		    constraintVCGType * * removeVCG)
 {
     ulong			scc;
     ulong			net;
@@ -637,19 +625,14 @@ RemoveConstraintVCG(nodeVCGType * VCG,
     }
 }
 
-ulong
-ExistPathAboveVCG(nodeVCGType * VCG,
-		  ulong above,
-		  ulong below)
+ulong ExistPathAboveVCG(nodeVCGType * VCG,		  ulong above,		  ulong below)
 {
     DFSClearVCG(VCG);
     DFSAboveVCG(VCG, above);
     return(VCG[below].netsAboveReached);
 }
 
-void
-LongestPathVCG(nodeVCGType * VCG,
-	       ulong net)
+void LongestPathVCG(nodeVCGType * VCG,	       ulong net)
 {
     ulong	track;
     ulong	bot;
@@ -711,9 +694,7 @@ LongestPathVCG(nodeVCGType * VCG,
     cardNotPref = not;
 }
 
-ulong
-DFSAboveLongestPathVCG(nodeVCGType * VCG,
-		       ulong net)
+ulong DFSAboveLongestPathVCG(nodeVCGType * VCG,		       ulong net)
 {
     ulong	s;
     ulong 	above;
@@ -737,9 +718,7 @@ DFSAboveLongestPathVCG(nodeVCGType * VCG,
     return(longest+1);
 }
 
-ulong
-DFSBelowLongestPathVCG(nodeVCGType * VCG,
-		       ulong net)
+ulong DFSBelowLongestPathVCG(nodeVCGType * VCG,		       ulong net)
 {
     ulong	s;
     ulong 	below;
@@ -763,11 +742,7 @@ DFSBelowLongestPathVCG(nodeVCGType * VCG,
     return(longest+1);
 }
 
-ulong
-VCV(nodeVCGType * VCG,
-    ulong check,
-    ulong track,
-    ulong * assign)
+ulong VCV(nodeVCGType * VCG,    ulong check,    ulong track,    ulong * assign)
 {
     ulong	net;
     ulong	vcv;

--- a/src/Ptrdist/yacr2/orig/vcg.h
+++ b/src/Ptrdist/yacr2/orig/vcg.h
@@ -63,20 +63,6 @@ typedef struct _nodeVCGType {
  *
  */
 
-#ifdef VCG_CODE
-
-nodeVCGType *			VCG;
-constraintVCGType *			storageRootVCG;
-constraintVCGType *			storageVCG;
-ulong					storageLimitVCG;
-constraintVCGType * *		removeVCG;
-ulong					removeTotalVCG;
-ulong *				SCC;
-ulong					totalSCC;
-ulong *				perSCC;
-
-#else	/* VCG_CODE */
-
 extern nodeVCGType *			VCG;
 extern constraintVCGType *		storageRootVCG;
 extern constraintVCGType *		storageVCG;
@@ -87,8 +73,6 @@ extern ulong *			SCC;
 extern ulong				totalSCC;
 extern ulong *			perSCC;
 
-#endif	/* VCG_CODE */
-
 
 /*
  *
@@ -96,8 +80,6 @@ extern ulong *			perSCC;
  *
  */
 
-#ifdef VCG_CODE
-
 void
 AllocVCG(void);
 
@@ -114,140 +96,30 @@ void
 DumpVCG(nodeVCGType *);
 
 void
-DFSAboveVCG(nodeVCGType *,
-	    ulong);
+DFSAboveVCG(nodeVCGType *,	    ulong);
 
-void
-DFSBelowVCG(nodeVCGType *,
-	    ulong);
+void DFSBelowVCG(nodeVCGType *,	    ulong);
 
-void
-SCCofVCG(nodeVCGType *,
-	 ulong *,
-	 ulong *);
+void SCCofVCG(nodeVCGType *,	 ulong *, 	 ulong *);
 
-void
-SCC_DFSAboveVCG(nodeVCGType *,
-		ulong,
-		ulong *);
+void SCC_DFSAboveVCG(nodeVCGType *,		ulong,		ulong *);
 
-void
-SCC_DFSBelowVCG(nodeVCGType *,
-		ulong,
-		ulong);
+void SCC_DFSBelowVCG(nodeVCGType *,		ulong,		ulong);
 
-void
-DumpSCC(ulong *,
-	ulong *);
+void DumpSCC(ulong *,	ulong *);
 
-void
-AcyclicVCG(void);
+void AcyclicVCG(void);
 
-void
-RemoveConstraintVCG(nodeVCGType *,
-		    ulong *,
-		    ulong *,
-		    constraintVCGType * *);
+void RemoveConstraintVCG(nodeVCGType *,		    ulong *,		    ulong *,		    constraintVCGType * *);
 
-ulong
-ExistPathAboveVCG(nodeVCGType *,
-		  ulong,
-		  ulong);
+ulong ExistPathAboveVCG(nodeVCGType *,		  ulong,		  ulong);
 
-void
-LongestPathVCG(nodeVCGType *,
-	       ulong);
+void LongestPathVCG(nodeVCGType *,	       ulong);
 
-ulong
-DFSAboveLongestPathVCG(nodeVCGType *,
-		       ulong);
+ulong DFSAboveLongestPathVCG(nodeVCGType *,		       ulong);
 
-ulong
-DFSBelowLongestPathVCG(nodeVCGType *,
-		       ulong);
+ulong DFSBelowLongestPathVCG(nodeVCGType *, 		       ulong);
 
-ulong
-VCV(nodeVCGType *,
-    ulong,
-    ulong,
-    ulong *);
-
-#else	/* VCG_CODE */
-
-extern void
-AllocVCG(void);
-
-extern void
-FreeVCG(void);
-
-extern void
-BuildVCG(void);
-
-extern void
-DFSClearVCG(nodeVCGType *);
-
-extern void
-DumpVCG(nodeVCGType *);
-
-extern void
-DFSAboveVCG(nodeVCGType *,
-	    ulong);
-
-extern void
-DFSBelowVCG(nodeVCGType *,
-	    ulong);
-
-extern void
-SCCofVCG(nodeVCGType *,
-	 ulong *,
-	 ulong *);
-
-extern void
-SCC_DFSAboveVCG(nodeVCGType *,
-		ulong,
-		ulong *);
-
-extern void
-SCC_DFSBelowVCG(nodeVCGType *,
-		ulong,
-		ulong);
-
-extern void
-DumpSCC(ulong *,
-	ulong *);
-
-extern void
-AcyclicVCG(void);
-
-extern void
-RemoveConstraintVCG(nodeVCGType *,
-		    ulong *,
-		    ulong *,
-		    constraintVCGType * *);
-
-extern ulong
-ExistPathAboveVCG(nodeVCGType *,
-		  ulong,
-		  ulong);
-
-extern void
-LongestPathVCG(nodeVCGType *,
-	       ulong);
-
-extern ulong
-DFSAboveLongestPathVCG(nodeVCGType *,
-		       ulong);
-
-extern ulong
-DFSBelowLongestPathVCG(nodeVCGType *,
-		       ulong);
-
-extern ulong
-VCV(nodeVCGType *,
-    ulong,
-    ulong,
-    ulong *);
-
-#endif	/* VCG_CODE */
+ulong VCV(nodeVCGType *,    ulong,    ulong,    ulong *);
 
 #endif	/* VCG_H */


### PR DESCRIPTION
Lots of diffs, but only three conceptual changes:

1. Pattern of defining and `extern`ing things in a header file, removed: definitions relocated into the appropriate file, header updated to just have `extern`s. Happened in several files: `assign.c`, `channel.c`, `hcg.c`, `vcg.c`
2. Function prototypes with checked pointers moved on to one line
3. Replaced `bzero` with `memset`, for which we have a checked header
